### PR TITLE
https://fossil.kd2.org/garradin/tktview?name=a806776598

### DIFF
--- a/src/include/lib/Garradin/Recherche.php
+++ b/src/include/lib/Garradin/Recherche.php
@@ -616,7 +616,7 @@ class Recherche
 
 		if (null !== $force_select)
 		{
-			$query = preg_replace('/^\s*SELECT.*FROM\s+/Uis', 'SELECT ' . implode(', ', $force_select) . ' FROM ', $query);
+			$query = preg_replace('/^\s*SELECT(.*)FROM\s+/Uis', 'SELECT \1,' . implode(', ', $force_select) . ' FROM ', $query); //force_select values are ADDED to the query
 		}
 
 		if (!$no_limit && !preg_match('/LIMIT\s+\d+/i', $query))

--- a/src/include/lib/Garradin/Utils.php
+++ b/src/include/lib/Garradin/Utils.php
@@ -1158,4 +1158,61 @@ class Utils
         }
         return $r;
     }
+
+    /**
+    * automatically translates fields to #tags for replacement
+    * alphanumerical are kept
+    * spaces (tabs & so on) are replaced by _
+    * other char. are removed
+    */
+    static public function translateMessage($message, $recipient) {
+      $replace = [];
+      foreach($recipient as $key => $value) {
+        if(strpos($key,"#") === 0) {
+          $key = substr($key,1); //added back in replaceTagsInContent
+        }
+        $key = preg_replace("/\W/","",preg_replace("/\s/","_",strtoupper($key))); //remove non alphanumerical and replace spaces by _
+        $replace[$key] = $value;
+      }
+      return self::replaceTagsInContent($message, $replace);
+    }
+
+
+    /**
+    *  returns the list of unset tags regarding the SQL query or selection
+    **/
+    static public function containsTags($message) {
+      preg_match_all("/#(\w+|[_]+)/m",$message,$matchs);
+      return (isset($matchs[0]) ? $matchs[0] : false);
+    }
+
+    /**
+  	 * Remplacer les tags présents dans une chaine de caractères
+  	 * @param  string $content Chaîne à traiter
+  	 * @param  array  $data    Données supplémentaires à utiliser comme tags (tableau associatif)
+  	 * @return string          $content dont les tags ont été remplacés par le contenu correct
+  	 */
+  	static public function replaceTagsInContent(string $content, ?array $data = null){
+  		$config = Config::getInstance();
+  		$tags = [
+  			'#NOM_ASSO'		=>	$config->get('nom_asso'),
+  			'#ADRESSE_ASSO'	=>	$config->get('adresse_asso'),
+  			'#EMAIL_ASSO'	=>	$config->get('email_asso'),
+  			'#SITE_ASSO'	=>	$config->get('site_asso'),
+  			'#URL_RACINE'	=>	WWW_URL,
+  			'#URL_SITE'		=>	WWW_URL,
+  			'#URL_ADMIN'	=>	ADMIN_URL,
+  		];
+
+  		if (!empty($data) && is_array($data))
+  		{
+  			foreach ($data as $key=>$value)
+  			{
+  				$key = '#' . strtoupper($key);
+  				$tags[$key] = $value;
+  			}
+  		}
+
+  		return strtr($content, $tags);
+  	}
 }

--- a/src/www/admin/membres/message_collectif.php
+++ b/src/www/admin/membres/message_collectif.php
@@ -27,7 +27,7 @@ if (f('send'))
         else
         {
             try {
-                $recipients = $recherche->search($match[2], ['membres.id', 'membres.email'], true);
+                $recipients = $recherche->search($match[2], ['membres.id AS "#IDENTITE"', 'membres.email AS "#EMAIL"'], true);
             }
             catch (UserException $e) {
                 $form->addError($e->getMessage());


### PR DESCRIPTION
J'ai essayé de comprendre le besoin, je ne sais pas les impacts.. j'ai essayé de limiter le + possible

message_collectif.php : je force des tags en dur pour ne pas les reprendre depuis une requete SQL perso (risque possible d'écrasement par des champs d'une requête personnalisé, à voir si on peut faire mieux)

Utils : ajout des méthodes pour traiter les tags

=> Le principe c'est que chacun des champs de la requête devient un tag de remplacement automatique (avec nettoyage)

Lorsque dans sendMessage je détecte #EMAIL + #IDENTITE je force les attributs de $recipients (id + email)

Dans Recherche.php, on n'écrase plus les champs sélectionnés, on les complète

Enfin, avant de transmettre je check s'il reste des tags non remplis.. et lance une exception (je pense que c'est trop car il est fort possible que l'utilisateur utilise des hashtag pour le plaisir d'utiliser des hashtags)

Peut-être qu'il faudrait une étape de confirmation au lieu de l'exception

Je comprend pas trop smartyer, j'aurais voulu selectionner le filtre "recipients" en cas d'exception, afin de resélectionner le choix..