### PR TITLE
Exclure les contributions volontaire du graphe temporel

### DIFF
--- a/src/include/lib/Paheko/Accounting/Graph.php
+++ b/src/include/lib/Paheko/Accounting/Graph.php
@@ -44,8 +44,8 @@ class Graph
 			'En attente' => ['type' => Account::TYPE_OUTSTANDING, 'exclude_position' => [Account::LIABILITY]],
 		],
 		'result' => [
-			'Recettes' => ['position' => Account::REVENUE],
-			'Dépenses' => ['position' => Account::EXPENSE],
+			'Recettes' => ['position' => Account::REVENUE, 'exclude_type' => Account::TYPE_VOLUNTEERING_REVENUE],
+			'Dépenses' => ['position' => Account::EXPENSE, 'exclude_type' => Account::TYPE_VOLUNTEERING_EXPENSE],
 		],
 		'debts' => [
 			'Comptes de tiers' => ['type' => Account::TYPE_THIRD_PARTY],


### PR DESCRIPTION
Les contributions volontaires sont prises en compte dans le graphe temporel, ce qui peut donner des résultats assez illisibles notamment lorsqu'on ajoute une seule écriture pour le volontariat en fin d'exercice.
Je ne suis pas certain qu'inclure les contributions volontaires soit d'une grande utilité puisque ce graphe sert à comparer les dépenses et les recettes, alors que les contributions volontaires font toujours monter les deux courbes de manière synchronisée.


# Avant
![image](https://github.com/user-attachments/assets/9e58c15c-fb03-4189-b908-8aac9974cc31)

# Après 
![image](https://github.com/user-attachments/assets/6a3257f7-fad9-4c5d-831f-f8ea2d34da65)
